### PR TITLE
🔀 :: 토큰 재발급 api 오류 수정

### DIFF
--- a/src/main/java/com/tomato/running/domain/auth/service/ReissueTokenService.java
+++ b/src/main/java/com/tomato/running/domain/auth/service/ReissueTokenService.java
@@ -7,7 +7,6 @@ import com.tomato.running.global.annotation.TransactionService;
 import com.tomato.running.global.security.jwt.TokenProvider;
 import com.tomato.running.global.security.util.count.RefreshToken;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.UUID;
 

--- a/src/main/java/com/tomato/running/domain/auth/service/ReissueTokenService.java
+++ b/src/main/java/com/tomato/running/domain/auth/service/ReissueTokenService.java
@@ -7,6 +7,7 @@ import com.tomato.running.global.annotation.TransactionService;
 import com.tomato.running.global.security.jwt.TokenProvider;
 import com.tomato.running.global.security.util.count.RefreshToken;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.UUID;
 
@@ -23,14 +24,16 @@ public class ReissueTokenService {
         RefreshToken findRefreshToken = refreshTokenRepository.findByToken(parseRefreshToken)
                 .orElseThrow(TokenNotFoundException::new);
 
+        refreshTokenRepository.deleteById(findRefreshToken.getUserId());
+
         TokenDto tokenDto = tokenProvider.generateTokenDto(findRefreshToken.getUserId());
 
-        saveFreshToken(tokenDto.getRefreshToken(), findRefreshToken.getUserId());
+        saveRefreshToken(tokenDto.getRefreshToken(), findRefreshToken.getUserId());
 
         return tokenDto;
     }
 
-    private void saveFreshToken(String token, UUID id) {
+    private void saveRefreshToken(String token, UUID id) {
         RefreshToken refreshToken = RefreshToken.builder()
                 .userId(id)
                 .token(token)

--- a/src/main/java/com/tomato/running/global/error/CustomException.java
+++ b/src/main/java/com/tomato/running/global/error/CustomException.java
@@ -1,10 +1,10 @@
 package com.tomato.running.global.error;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class CustomException extends RuntimeException{
-    ErrorCode errorCode;
+    private final ErrorCode errorCode;
 }

--- a/src/main/java/com/tomato/running/global/security/jwt/TokenProvider.java
+++ b/src/main/java/com/tomato/running/global/security/jwt/TokenProvider.java
@@ -24,7 +24,7 @@ public class TokenProvider {
     private final AuthDetailsService authDetailsService;
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_TYPE = "Bearer ";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 60L * 15 * 4;
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 60L * 30;
     public static final long REFRESH_TOKEN_EXPIRE_TIME = 60L * 60 * 24 * 7;
 
 

--- a/src/main/java/com/tomato/running/global/security/jwt/TokenProvider.java
+++ b/src/main/java/com/tomato/running/global/security/jwt/TokenProvider.java
@@ -23,9 +23,10 @@ public class TokenProvider {
 
     private final AuthDetailsService authDetailsService;
     private static final String AUTHORITIES_KEY = "auth";
-    private static final String BEARER_TYPE = "Bearer";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30분
-    public static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // 7일
+    private static final String BEARER_TYPE = "Bearer ";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 60L * 15 * 4;
+    public static final long REFRESH_TOKEN_EXPIRE_TIME = 60L * 60 * 24 * 7;
+
 
     private final Key key;
 
@@ -48,9 +49,7 @@ public class TokenProvider {
 
 
     private String generateAccessToken(UUID userid) {
-        long now = (new Date()).getTime();
-
-        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        Date accessTokenExpiresIn = new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME * 1000);
 
         return Jwts.builder()
                 .setSubject(userid.toString())
@@ -62,10 +61,7 @@ public class TokenProvider {
     }
 
     private String generateRefreshToken(UUID userid) {
-
-        long now = (new Date()).getTime();
-
-        Date refreshTokenExpiresIn = new Date(now + REFRESH_TOKEN_EXPIRE_TIME);
+        Date refreshTokenExpiresIn = new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRE_TIME * 1000);
 
         return Jwts.builder()
                 .setSubject(userid.toString())

--- a/src/main/java/com/tomato/running/global/security/jwt/TokenProvider.java
+++ b/src/main/java/com/tomato/running/global/security/jwt/TokenProvider.java
@@ -69,6 +69,7 @@ public class TokenProvider {
 
         return Jwts.builder()
                 .setSubject(userid.toString())
+                .claim(AUTHORITIES_KEY, "JWT")
                 .setExpiration(refreshTokenExpiresIn)
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();

--- a/src/main/java/com/tomato/running/global/security/jwt/TokenProvider.java
+++ b/src/main/java/com/tomato/running/global/security/jwt/TokenProvider.java
@@ -39,7 +39,7 @@ public class TokenProvider {
 
     public TokenDto generateTokenDto(UUID userid){
         return TokenDto.builder()
-                .grantType(BEARER_TYPE)
+                .grantType("Bearer")
                 .accessToken(generateAccessToken(userid))
                 .refreshToken(generateRefreshToken(userid))
                 .accessTokenExpiresIn(ACCESS_TOKEN_EXPIRE_TIME)

--- a/src/main/java/com/tomato/running/global/security/util/count/RefreshToken.java
+++ b/src/main/java/com/tomato/running/global/security/util/count/RefreshToken.java
@@ -1,6 +1,5 @@
 package com.tomato.running.global.security.util.count;
 
-import com.tomato.running.global.security.jwt.TokenProvider;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
@@ -9,7 +8,7 @@ import org.springframework.data.redis.core.index.Indexed;
 
 import java.util.UUID;
 
-@RedisHash(value = "running_refreshToken", timeToLive = TokenProvider.REFRESH_TOKEN_EXPIRE_TIME)
+@RedisHash(value = "running_refreshToken", timeToLive = 60L * 60 * 24 * 7)
 @Builder
 @Getter
 public class RefreshToken {


### PR DESCRIPTION
## 💡 배경 및 개요

토큰 재발급 api의 오류를 수정하고 리프레쉬 토큰의 설정을 추가하였습니다

Resolves: #49 

## 📃 작업내용

* BEARER_TYPE의 값 끝에 공백 추가 및 반환 Dto엔 공백 제거

## 🙋‍♂️ 리뷰노트
이번 이슈와는 상관없지만 테스트를 하던 도중 RefreshToken의 TTL이 비정상적으로 길어 직접 시간을 입력하는 방식으로 수정하였습니다

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g.  `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타