### PR TITLE
🔀 :: 런닝글에 대한 런닝 처리 수정

### DIFF
--- a/src/main/java/com/tomato/running/domain/auth/service/LoginService.java
+++ b/src/main/java/com/tomato/running/domain/auth/service/LoginService.java
@@ -44,8 +44,6 @@ public class LoginService {
     }
 
     private User newUser(NaverInfoResponse naverInfoResponse) {
-        RunningUser runningUser = saveRunningUser();
-
         User user = User.builder()
                 .email(naverInfoResponse.getEmail())
                 .name(naverInfoResponse.getName())
@@ -53,10 +51,13 @@ public class LoginService {
                 .age(naverInfoResponse.getAge())
                 .mobile(naverInfoResponse.getMobile())
                 .role(Role.ROLE_USER)
-                .runningUser(runningUser)
                 .build();
 
-        return userRepository.save(user);
+        userRepository.save(user);
+
+        saveRunningUser(user);
+
+        return user;
     }
 
     private void saveRefreshToken(String token, UUID id) {
@@ -68,13 +69,14 @@ public class LoginService {
         refreshTokenRepository.save(refreshToken);
     }
 
-    private RunningUser saveRunningUser() {
+    private RunningUser saveRunningUser(User user) {
         RunningUser runningUser = RunningUser.builder()
                 .totalDistance(0)
                 .bestDistance(0)
                 .worstDistance(null)
                 .levelPercentage(0)
                 .level(0)
+                .user(user)
                 .build();
 
         runningUserRepository.save(runningUser);

--- a/src/main/java/com/tomato/running/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/tomato/running/domain/meeting/entity/Meeting.java
@@ -29,7 +29,6 @@ public class Meeting {
     @Column(nullable = false)
     private Integer distance;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
     @Column(nullable = false)
     private LocalDateTime startAt;
 

--- a/src/main/java/com/tomato/running/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/tomato/running/domain/meeting/entity/Meeting.java
@@ -54,4 +54,8 @@ public class Meeting {
         this.addressDetail = addressDetail;
     }
 
+    public void updateStatus() {
+        this.status = false;
+    }
+
 }

--- a/src/main/java/com/tomato/running/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/tomato/running/domain/meeting/entity/Meeting.java
@@ -38,6 +38,9 @@ public class Meeting {
     @Column(nullable = false, columnDefinition = "VARCHAR(50)")
     private String addressDetail;
 
+    @Column(nullable = false)
+    private Boolean status;
+
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;

--- a/src/main/java/com/tomato/running/domain/meeting/entity/MeetingMember.java
+++ b/src/main/java/com/tomato/running/domain/meeting/entity/MeetingMember.java
@@ -30,4 +30,8 @@ public class MeetingMember {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    public void updateStatus() {
+        this.status = true;
+    }
 }

--- a/src/main/java/com/tomato/running/domain/meeting/entity/MeetingMember.java
+++ b/src/main/java/com/tomato/running/domain/meeting/entity/MeetingMember.java
@@ -20,6 +20,9 @@ public class MeetingMember {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
 
+    @Column(nullable = false)
+    private Boolean status;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meeting_id", nullable = false)
     private Meeting meeting;

--- a/src/main/java/com/tomato/running/domain/meeting/repository/MeetingMemberRepository.java
+++ b/src/main/java/com/tomato/running/domain/meeting/repository/MeetingMemberRepository.java
@@ -19,6 +19,7 @@ public interface MeetingMemberRepository extends JpaRepository<MeetingMember, UU
     Boolean existsByMeetingAndUser(Meeting meeting, User user);
     void deleteAllByMeeting(Meeting meeting);
     void deleteByMeetingAndUser(Meeting meeting, User user);
-
+    Optional<MeetingMember> findByMeetingAndUser(Meeting meeting, User user);
+    Boolean existsByMeetingAndStatus(Meeting meeting, Boolean status);
 }
 

--- a/src/main/java/com/tomato/running/domain/meeting/repository/MeetingMemberRepository.java
+++ b/src/main/java/com/tomato/running/domain/meeting/repository/MeetingMemberRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface MeetingMemberRepository extends JpaRepository<MeetingMember, UUID> {

--- a/src/main/java/com/tomato/running/domain/meeting/service/ApplicationMeetingService.java
+++ b/src/main/java/com/tomato/running/domain/meeting/service/ApplicationMeetingService.java
@@ -37,6 +37,7 @@ public class ApplicationMeetingService {
         MeetingMember meetingMember = MeetingMember.builder()
                 .meeting(meeting)
                 .user(user)
+                .status(false)
                 .build();
 
         meetingMemberRepository.save(meetingMember);

--- a/src/main/java/com/tomato/running/domain/meeting/service/CreateMeetingService.java
+++ b/src/main/java/com/tomato/running/domain/meeting/service/CreateMeetingService.java
@@ -30,6 +30,7 @@ public class CreateMeetingService {
                 .startLocation(new StartLocation(dto.getStartLongitude(), dto.getStartLatitude()))
                 .addressDetail(dto.getAddressDetail())
                 .user(user)
+                .status(true)
                 .build();
 
         meetingRepository.save(meeting);

--- a/src/main/java/com/tomato/running/domain/meeting/service/CreateMeetingService.java
+++ b/src/main/java/com/tomato/running/domain/meeting/service/CreateMeetingService.java
@@ -41,6 +41,7 @@ public class CreateMeetingService {
         MeetingMember meetingMember = MeetingMember.builder()
                 .meeting(meeting)
                 .user(user)
+                .status(false)
                 .build();
 
         meetingMemberRepository.save(meetingMember);

--- a/src/main/java/com/tomato/running/domain/meeting/service/GetMeetingInfoService.java
+++ b/src/main/java/com/tomato/running/domain/meeting/service/GetMeetingInfoService.java
@@ -5,6 +5,9 @@ import com.tomato.running.domain.meeting.controller.data.res.GetMeetingInfoRespo
 import com.tomato.running.domain.meeting.exception.MeetingNotFoundException;
 import com.tomato.running.domain.meeting.repository.MeetingMemberRepository;
 import com.tomato.running.domain.meeting.repository.MeetingRepository;
+import com.tomato.running.domain.running.entity.RunningUser;
+import com.tomato.running.domain.running.exception.RunningUserNotFoundException;
+import com.tomato.running.domain.running.repository.RunningUserRepository;
 import com.tomato.running.global.annotation.ReadOnlyTransactionService;
 import lombok.RequiredArgsConstructor;
 
@@ -16,10 +19,14 @@ public class GetMeetingInfoService {
 
     private final MeetingRepository meetingRepository;
     private final MeetingMemberRepository meetingMemberRepository;
+    private final RunningUserRepository runningUserRepository;
 
     public GetMeetingInfoResponseDto getMeetingInfo(UUID meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(MeetingNotFoundException::new);
+
+        RunningUser runningUser = runningUserRepository.findByUser(meeting.getUser())
+                .orElseThrow(RunningUserNotFoundException::new);
 
         return GetMeetingInfoResponseDto.builder()
                 .title(meeting.getTitle())
@@ -27,7 +34,7 @@ public class GetMeetingInfoService {
                 .startAt(String.valueOf(meeting.getStartAt()))
                 .startLocation(meeting.getStartLocation())
                 .addressDetail(meeting.getAddressDetail())
-                .author(new GetMeetingInfoResponseDto.AuthorInformation(meeting.getUser().getName(), meeting.getUser().getRunningUser().getLevel()))
+                .author(new GetMeetingInfoResponseDto.AuthorInformation(meeting.getUser().getName(), runningUser.getLevel()))
                 .memberNum(meetingMemberRepository.countAllByMeeting(meeting))
                 .build();
     }

--- a/src/main/java/com/tomato/running/domain/run/entity/Run.java
+++ b/src/main/java/com/tomato/running/domain/run/entity/Run.java
@@ -1,5 +1,6 @@
 package com.tomato.running.domain.run.entity;
 
+import com.tomato.running.domain.meeting.entity.Meeting;
 import com.tomato.running.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -32,6 +33,10 @@ public class Run {
 
     @Column(columnDefinition = "TIME", nullable = false)
     private Time runningTime;
+
+    @ManyToOne
+    @JoinColumn(name = "meeting_id", nullable = false)
+    private Meeting meeting;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/tomato/running/domain/run/exception/MeetingMemberNotFoundException.java
+++ b/src/main/java/com/tomato/running/domain/run/exception/MeetingMemberNotFoundException.java
@@ -1,0 +1,10 @@
+package com.tomato.running.domain.run.exception;
+
+import com.tomato.running.global.error.CustomException;
+import com.tomato.running.global.error.ErrorCode;
+
+public class MeetingMemberNotFoundException extends CustomException {
+    public MeetingMemberNotFoundException() {
+        super(ErrorCode.MEETING_MEMBER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/tomato/running/domain/run/presentation/RunController.java
+++ b/src/main/java/com/tomato/running/domain/run/presentation/RunController.java
@@ -6,10 +6,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,9 +17,9 @@ public class RunController {
 
     private final RecordRunningService recordRunningService;
 
-    @PostMapping
-    public ResponseEntity<Void> recordRunning(@RequestBody @Valid RecordRunningRequestDto dto) {
-        recordRunningService.recordRunning(dto);
+    @PostMapping("{meeting_id}")
+    public ResponseEntity<Void> recordRunning(@PathVariable("meeting_id") UUID meetingId, @RequestBody @Valid RecordRunningRequestDto dto) {
+        recordRunningService.recordRunning(meetingId ,dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/com/tomato/running/domain/run/presentation/RunController.java
+++ b/src/main/java/com/tomato/running/domain/run/presentation/RunController.java
@@ -17,7 +17,7 @@ public class RunController {
 
     private final RecordRunningService recordRunningService;
 
-    @PostMapping("{meeting_id}")
+    @PostMapping("/{meeting_id}")
     public ResponseEntity<Void> recordRunning(@PathVariable("meeting_id") UUID meetingId, @RequestBody @Valid RecordRunningRequestDto dto) {
         recordRunningService.recordRunning(meetingId ,dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/src/main/java/com/tomato/running/domain/run/presentation/data/req/RecordRunningRequestDto.java
+++ b/src/main/java/com/tomato/running/domain/run/presentation/data/req/RecordRunningRequestDto.java
@@ -9,10 +9,6 @@ import java.sql.Time;
 @Getter
 @NoArgsConstructor
 public class RecordRunningRequestDto {
-
-    @NotNull
-    private Integer distance;
-
     @NotNull
     private Float startLongitude;
 

--- a/src/main/java/com/tomato/running/domain/run/service/RecordRunningService.java
+++ b/src/main/java/com/tomato/running/domain/run/service/RecordRunningService.java
@@ -14,6 +14,7 @@ import com.tomato.running.domain.run.presentation.data.req.RecordRunningRequestD
 import com.tomato.running.domain.run.repository.RunRepository;
 import com.tomato.running.domain.run.util.LevelUtil;
 import com.tomato.running.domain.running.entity.RunningUser;
+import com.tomato.running.domain.running.exception.RunningUserNotFoundException;
 import com.tomato.running.domain.running.repository.RunningUserRepository;
 import com.tomato.running.domain.user.entity.User;
 import com.tomato.running.domain.user.util.UserUtil;
@@ -61,7 +62,8 @@ public class RecordRunningService {
     }
 
     private void saveRunningUser(User user, Meeting meeting) {
-        RunningUser runningUser = user.getRunningUser();
+        RunningUser runningUser = runningUserRepository.findByUser(user)
+                .orElseThrow(RunningUserNotFoundException::new);
 
         Integer best = runningUser.getBestDistance() < meeting.getDistance() ? meeting.getDistance() : runningUser.getBestDistance();
 
@@ -82,6 +84,7 @@ public class RecordRunningService {
                 .totalDistance(newTotalDistance)
                 .levelPercentage(levelUtil.calculatePercentage(newTotalDistance))
                 .level(levelUtil.calculateLevel(newTotalDistance))
+                .user(user)
                 .build();
 
         runningUserRepository.save(newRunningUser);

--- a/src/main/java/com/tomato/running/domain/run/service/RecordRunningService.java
+++ b/src/main/java/com/tomato/running/domain/run/service/RecordRunningService.java
@@ -1,9 +1,15 @@
 package com.tomato.running.domain.run.service;
 
+import com.tomato.running.domain.meeting.entity.Meeting;
+import com.tomato.running.domain.meeting.entity.MeetingMember;
+import com.tomato.running.domain.meeting.exception.MeetingNotFoundException;
+import com.tomato.running.domain.meeting.repository.MeetingMemberRepository;
+import com.tomato.running.domain.meeting.repository.MeetingRepository;
 import com.tomato.running.domain.run.entity.EndLocation;
 import com.tomato.running.domain.run.entity.Run;
 import com.tomato.running.domain.run.entity.StartLocation;
 import com.tomato.running.domain.run.exception.InvalidRunDistanceException;
+import com.tomato.running.domain.run.exception.MeetingMemberNotFoundException;
 import com.tomato.running.domain.run.presentation.data.req.RecordRunningRequestDto;
 import com.tomato.running.domain.run.repository.RunRepository;
 import com.tomato.running.domain.run.util.LevelUtil;
@@ -14,51 +20,60 @@ import com.tomato.running.domain.user.util.UserUtil;
 import com.tomato.running.global.annotation.TransactionService;
 import lombok.RequiredArgsConstructor;
 
+import java.util.UUID;
+
 @TransactionService
 @RequiredArgsConstructor
 public class RecordRunningService {
 
     private final RunningUserRepository runningUserRepository;
+    private final MeetingRepository meetingRepository;
+    private final MeetingMemberRepository meetingMemberRepository;
     private final LevelUtil levelUtil;
     private final RunRepository runRepository;
     private final UserUtil userUtil;
 
-    public void recordRunning(RecordRunningRequestDto dto) {
+    public void recordRunning(UUID meetingId, RecordRunningRequestDto dto) {
         User user = userUtil.getCurrentUser();
 
-        if (dto.getDistance() < 0)
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(MeetingNotFoundException::new);
+
+        if (meeting.getDistance() < 0)
             throw new InvalidRunDistanceException();
 
-        saveRun(dto, user);
-        saveRunningUser(user, dto);
+        saveRun(dto, user, meeting);
+        saveRunningUser(user, meeting);
+        processMeetingMember(user, meeting);
     }
 
-    private void saveRun(RecordRunningRequestDto dto, User user) {
+    private void saveRun(RecordRunningRequestDto dto, User user, Meeting meeting) {
         Run run = Run.builder()
-                .distance(dto.getDistance())
+                .distance(meeting.getDistance())
                 .startLocation(new StartLocation(dto.getStartLongitude(), dto.getStartLatitude()))
                 .endLocation(new EndLocation(dto.getEndLongitude(), dto.getEndLatitude()))
                 .runningTime(dto.getRunningTime())
+                .meeting(meeting)
                 .user(user)
                 .build();
 
         runRepository.save(run);
     }
 
-    private void saveRunningUser(User user, RecordRunningRequestDto dto) {
+    private void saveRunningUser(User user, Meeting meeting) {
         RunningUser runningUser = user.getRunningUser();
 
-        Integer best = runningUser.getBestDistance() < dto.getDistance() ? dto.getDistance() : runningUser.getBestDistance();
+        Integer best = runningUser.getBestDistance() < meeting.getDistance() ? meeting.getDistance() : runningUser.getBestDistance();
 
         Integer worst;
 
         if (runningUser.getWorstDistance() == null) {
-            worst = dto.getDistance();
+            worst = meeting.getDistance();
         } else {
-            worst = runningUser.getWorstDistance() > dto.getDistance() ? dto.getDistance() : runningUser.getWorstDistance();
+            worst = runningUser.getWorstDistance() > meeting.getDistance() ? meeting.getDistance() : runningUser.getWorstDistance();
         }
 
-        Integer newTotalDistance = runningUser.getTotalDistance() + dto.getDistance();
+        Integer newTotalDistance = runningUser.getTotalDistance() + meeting.getDistance();
 
         RunningUser newRunningUser = RunningUser.builder()
                 .id(runningUser.getId())
@@ -70,5 +85,16 @@ public class RecordRunningService {
                 .build();
 
         runningUserRepository.save(newRunningUser);
+    }
+
+    private void processMeetingMember(User user, Meeting meeting) {
+        MeetingMember meetingMember = meetingMemberRepository.findByMeetingAndUser(meeting, user)
+                .orElseThrow(MeetingMemberNotFoundException::new);
+
+        meetingMember.updateStatus();
+
+        if (!meetingMemberRepository.existsByMeetingAndStatus(meeting, false)) {
+            meeting.updateStatus();
+        }
     }
 }

--- a/src/main/java/com/tomato/running/domain/running/entity/RunningUser.java
+++ b/src/main/java/com/tomato/running/domain/running/entity/RunningUser.java
@@ -1,5 +1,6 @@
 package com.tomato.running.domain.running.entity;
 
+import com.tomato.running.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,4 +34,8 @@ public class RunningUser {
 
     @Column(nullable = false, columnDefinition = "TINYINT")
     private Integer levelPercentage;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 }

--- a/src/main/java/com/tomato/running/domain/running/repository/RunningUserRepository.java
+++ b/src/main/java/com/tomato/running/domain/running/repository/RunningUserRepository.java
@@ -1,7 +1,11 @@
 package com.tomato.running.domain.running.repository;
 
 import com.tomato.running.domain.running.entity.RunningUser;
+import com.tomato.running.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RunningUserRepository extends JpaRepository<RunningUser, Long> {
+    Optional<RunningUser> findByUser(User user);
 }

--- a/src/main/java/com/tomato/running/domain/user/entity/User.java
+++ b/src/main/java/com/tomato/running/domain/user/entity/User.java
@@ -1,7 +1,6 @@
 package com.tomato.running.domain.user.entity;
 
-import com.tomato.running.domain.running.entity.RunningUser;
-import com.tomato.running.domain.user.controller.data.req.UpdateWeightAndHeightRequestDto;
+import com.tomato.running.domain.user.presentation.data.req.UpdateWeightAndHeightRequestDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -45,10 +44,6 @@ public class User {
     @Column(name = "role")
     @Enumerated(EnumType.STRING)
     private Role role;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "runningUser_id", nullable = false)
-    private RunningUser runningUser;
 
     public void saveWeightAndHeight(UpdateWeightAndHeightRequestDto dto) {
         this.height = dto.getHeight();

--- a/src/main/java/com/tomato/running/domain/user/presentation/UserController.java
+++ b/src/main/java/com/tomato/running/domain/user/presentation/UserController.java
@@ -1,8 +1,8 @@
-package com.tomato.running.domain.user.controller;
+package com.tomato.running.domain.user.presentation;
 
 import com.tomato.running.domain.meeting.controller.data.res.GetMeetingResponseDto;
-import com.tomato.running.domain.user.controller.data.req.UpdateWeightAndHeightRequestDto;
-import com.tomato.running.domain.user.controller.data.res.GetMyInformationResponseDto;
+import com.tomato.running.domain.user.presentation.data.req.UpdateWeightAndHeightRequestDto;
+import com.tomato.running.domain.user.presentation.data.res.GetMyInformationResponseDto;
 import com.tomato.running.domain.user.service.GetMeetingsService;
 import com.tomato.running.domain.user.service.GetMyApplicationMeetingService;
 import com.tomato.running.domain.user.service.GetMyInformationService;

--- a/src/main/java/com/tomato/running/domain/user/presentation/data/req/UpdateWeightAndHeightRequestDto.java
+++ b/src/main/java/com/tomato/running/domain/user/presentation/data/req/UpdateWeightAndHeightRequestDto.java
@@ -1,4 +1,4 @@
-package com.tomato.running.domain.user.controller.data.req;
+package com.tomato.running.domain.user.presentation.data.req;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;

--- a/src/main/java/com/tomato/running/domain/user/presentation/data/res/GetMyInformationResponseDto.java
+++ b/src/main/java/com/tomato/running/domain/user/presentation/data/res/GetMyInformationResponseDto.java
@@ -1,4 +1,4 @@
-package com.tomato.running.domain.user.controller.data.res;
+package com.tomato.running.domain.user.presentation.data.res;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/tomato/running/domain/user/service/GetMyInformationService.java
+++ b/src/main/java/com/tomato/running/domain/user/service/GetMyInformationService.java
@@ -2,7 +2,7 @@ package com.tomato.running.domain.user.service;
 
 import com.tomato.running.domain.running.repository.RunningUserRepository;
 import com.tomato.running.domain.user.entity.User;
-import com.tomato.running.domain.user.controller.data.res.GetMyInformationResponseDto;
+import com.tomato.running.domain.user.presentation.data.res.GetMyInformationResponseDto;
 import com.tomato.running.domain.user.util.UserUtil;
 import com.tomato.running.global.annotation.ReadOnlyTransactionService;
 

--- a/src/main/java/com/tomato/running/domain/user/service/GetMyInformationService.java
+++ b/src/main/java/com/tomato/running/domain/user/service/GetMyInformationService.java
@@ -1,5 +1,7 @@
 package com.tomato.running.domain.user.service;
 
+import com.tomato.running.domain.running.entity.RunningUser;
+import com.tomato.running.domain.running.exception.RunningUserNotFoundException;
 import com.tomato.running.domain.running.repository.RunningUserRepository;
 import com.tomato.running.domain.user.entity.User;
 import com.tomato.running.domain.user.presentation.data.res.GetMyInformationResponseDto;
@@ -18,16 +20,19 @@ public class GetMyInformationService {
     public GetMyInformationResponseDto getMyInformation() {
         User user = userUtil.getCurrentUser();
 
+        RunningUser runningUser = runningUserRepository.findByUser(user)
+                .orElseThrow(RunningUserNotFoundException::new);
+
         return GetMyInformationResponseDto.builder()
                 .id(user.getId())
                 .name(user.getName())
                 .height(user.getHeight())
                 .weight(user.getWeight())
                 .runningUser(GetMyInformationResponseDto.runningUserDto.builder()
-                        .totalDistance(user.getRunningUser().getTotalDistance())
-                        .bestDistance(user.getRunningUser().getBestDistance())
-                        .worstDistance(user.getRunningUser().getWorstDistance())
-                        .levelPercentage(user.getRunningUser().getLevelPercentage())
+                        .totalDistance(runningUser.getTotalDistance())
+                        .bestDistance(runningUser.getBestDistance())
+                        .worstDistance(runningUser.getWorstDistance())
+                        .levelPercentage(runningUser.getLevelPercentage())
                         .build())
                 .build();
     }

--- a/src/main/java/com/tomato/running/domain/user/service/UpdateWeightAndHeightService.java
+++ b/src/main/java/com/tomato/running/domain/user/service/UpdateWeightAndHeightService.java
@@ -1,7 +1,7 @@
 package com.tomato.running.domain.user.service;
 
 import com.tomato.running.domain.user.entity.User;
-import com.tomato.running.domain.user.controller.data.req.UpdateWeightAndHeightRequestDto;
+import com.tomato.running.domain.user.presentation.data.req.UpdateWeightAndHeightRequestDto;
 import com.tomato.running.domain.user.repository.UserRepository;
 import com.tomato.running.domain.user.util.UserUtil;
 import com.tomato.running.global.annotation.TransactionService;

--- a/src/main/java/com/tomato/running/global/error/ErrorCode.java
+++ b/src/main/java/com/tomato/running/global/error/ErrorCode.java
@@ -28,7 +28,8 @@ public enum ErrorCode {
     MEMBER_NOT_VALID(401, "MEMBER_NOT_VALID"),
 
     // meetingMember
-    ALREADY_EXIST_MEETING_MEMBER(409, "ALREADY_EXIST_MEETING_MEMBER"),;
+    ALREADY_EXIST_MEETING_MEMBER(409, "ALREADY_EXIST_MEETING_MEMBER"),
+    MEETING_MEMBER_NOT_FOUND(404, "MEETING_MEMBER_NOT_FOUND"),;
     private final int status;
     private final String message;
 }

--- a/src/main/java/com/tomato/running/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/tomato/running/global/security/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.GET, "/user/meetings/application").authenticated()
 
                                 // run
-                                .requestMatchers(HttpMethod.POST, "/run").authenticated()
+                                .requestMatchers(HttpMethod.POST, "/run/{meeting_id}").authenticated()
 
                                 //meeting
                                 .requestMatchers(HttpMethod.POST, "/meeting").authenticated()


### PR DESCRIPTION
## 💡 배경 및 개요

런닝 글에서 모든 사람이 런닝을 마친 경우 런닝글을 자동으로 종료되게 만들기 위해 각 엔티티에 status와 연관관계를 매핑하였습니다

Resolves: #51 

## 📃 작업내용

* Meeting과 MeetingMember에 status 컬럼 추가
* 런닝 기록 후 런닝 종료 자동화를 위한 processMeetingMember 메서드 추가

## 🙋‍♂️ 리뷰노트


## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g.  `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타